### PR TITLE
Add packagemanager as 2nd category

### DIFF
--- a/other/assets/gui/io.github.accessory.minus_games_gui.metainfo.xml
+++ b/other/assets/gui/io.github.accessory.minus_games_gui.metainfo.xml
@@ -38,7 +38,7 @@
 
     <categories>
         <category>Game</category>
-        <category>Utility</category>
+        <category>PackageManager</category>
     </categories>
 
     <provides>


### PR DESCRIPTION
This would sort it with the other launchers on flathub

![image](https://github.com/user-attachments/assets/83d12b82-59d6-484f-8bd5-9f7218419ce2)
